### PR TITLE
[puppetforge] Apply generic HTTP client to PuppetForge

### DIFF
--- a/perceval/__init__.py
+++ b/perceval/__init__.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import logging
+
+from ._version import __version__
+from .backend import find_backends
+
+__all__ = [__version__, find_backends]
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/perceval/backends/puppet/puppetforge.py
+++ b/perceval/backends/puppet/puppetforge.py
@@ -23,8 +23,6 @@
 import json
 import logging
 
-import requests
-
 from grimoirelab.toolkit.datetime import datetime_to_utc, str_to_datetime
 from grimoirelab.toolkit.uris import urijoin
 
@@ -33,6 +31,7 @@ from ...backend import (Backend,
                         BackendCommand,
                         BackendCommandArgumentParser,
                         metadata)
+from ...client import HttpClient
 from ...utils import DEFAULT_DATETIME
 
 
@@ -205,7 +204,7 @@ class PuppetForge(Backend):
         return result
 
 
-class PuppetForgeClient:
+class PuppetForgeClient(HttpClient):
     """Puppet forge REST API client.
 
     This class implements a simple client to retrieve data
@@ -230,7 +229,7 @@ class PuppetForgeClient:
     VRELEASE_DATE = 'release_date'
 
     def __init__(self, base_url, max_items=MAX_ITEMS):
-        self.base_url = base_url
+        super().__init__(base_url)
         self.max_items = max_items
 
     def modules(self):
@@ -291,8 +290,7 @@ class PuppetForgeClient:
             logger.debug("Puppet forge client calls resource: %s params: %s",
                          resource, str(params))
 
-            r = requests.get(url, params=params)
-            r.raise_for_status()
+            r = self.fetch(url, payload=params)
             yield r.text
 
             json_data = r.json()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -26,6 +26,6 @@ import unittest
 
 
 if __name__ == '__main__':
-    test_suite = unittest.TestLoader().discover('.', pattern='test*.py')
+    test_suite = unittest.TestLoader().discover('.', pattern='test_*.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/test_puppetforge.py
+++ b/tests/test_puppetforge.py
@@ -21,17 +21,10 @@
 #
 
 import datetime
-import sys
 import unittest
 
 import dateutil.tz
 import httpretty
-import pkg_resources
-
-# Hack to make sure that tests import the right packages
-# due to setuptools behaviour
-sys.path.insert(0, '..')
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.puppet.puppetforge import (PuppetForge,


### PR DESCRIPTION
The generic client is applied to the PuppetForge backend. Now connection problems are transparently handled by the generic client.