### PR TITLE
[setup] Update minimum version of perceval required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ except (IOError, ImportError):
         long_description = f.read()
 
 
-version = '0.1.0.dev5'
+version = '0.1.1'
 
 
 setup(name="perceval-puppet",
@@ -75,6 +75,6 @@ setup(name="perceval-puppet",
       install_requires=[
           'requests>=2.7.0',
           'grimoirelab-toolkit>=0.1.0',
-          'perceval>=0.8'
+          'perceval>=0.9'
       ],
       zip_safe=False)


### PR DESCRIPTION
This patch target issue #2 . It updates the minimum version of Perceval required
  